### PR TITLE
Hide plugin from napari hub

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,3 +1,4 @@
+visibility: hidden
 project_urls:
     Bug Tracker: https://github.com/DragaDoncila/example-plugin/issues
     Documentation: https://github.com/DragaDoncila/example-plugin#README.md


### PR DESCRIPTION
include visibility flag, this would hide the plugin from napari hub home page, but still allows access on the plugin page with the correct URL