### PR TITLE
put urls in standard metadata

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,6 +1,1 @@
 visibility: hidden
-project_urls:
-    Bug Tracker: https://github.com/DragaDoncila/example-plugin/issues
-    Documentation: https://github.com/DragaDoncila/example-plugin#README.md
-    Source Code: https://github.com/DragaDoncila/example-plugin
-    User Support: https://github.com/DragaDoncila/example-plugin/issues

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,11 @@ classifiers =
     Programming Language :: Python :: 3.9
     Operating System :: OS Independent
     License :: OSI Approved :: BSD License
-
+project_urls =
+    Bug Tracker = https://github.com/DragaDoncila/example-plugin/issues
+    Documentation = https://github.com/DragaDoncila/example-plugin#README.md
+    Source Code = https://github.com/DragaDoncila/example-plugin
+    User Support = https://github.com/DragaDoncila/example-plugin/issues
 
 [options]
 packages = find:


### PR DESCRIPTION
(hi @DragaDoncila ... sending auto prs fixing various problems with metadata.   i know this is just a test, but just in case anyone uses it as an example)

Hello, in going through some napari plugins with missing metadata, I found your urls in the wrong place.  This fixes that.  Note that you can use `.napari/config.yaml` if you'd like to _override_ how your page appears on the hub, but you should mimimally populate the official sources for  [standard metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) 